### PR TITLE
make bmp:load(...) -> bitmap actually return a bitmap

### DIFF
--- a/bmp.lua
+++ b/bmp.lua
@@ -490,6 +490,8 @@ M.open = glue.protect(function(read_bytes)
 			for j = j0, j1, step do
 				load_row(j)
 			end
+				
+			return dst_bmp
 		end
 
 	end


### PR DESCRIPTION
it seems this was forgotten but [described in the documentation](https://github.com/luapower/bmp/blob/master/bmp.md#bloadbmp-x-y---bmp--nilerr).